### PR TITLE
test: Use `toBeUndefined` over `toEqual(undefined)`

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -19,7 +19,7 @@ describe('utils', () => {
         }
       }
 
-      expect(getNowPlaying([track as any])).toEqual(undefined)
+      expect(getNowPlaying([track as any])).toBeUndefined()
     })
 
     it('returns undefined when @attr.nowplaying is undefined', () => {
@@ -30,7 +30,7 @@ describe('utils', () => {
         }
       }
 
-      expect(getNowPlaying([track as any])).toEqual(undefined)
+      expect(getNowPlaying([track as any])).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
`toEqual(undefined)` is more verbose than necessary, and Jest's
`toEqual` is only really necessary for value comparison (objects and
arrays), while `toBe` style methods are better suited to primitives and
strict equality checks.