### PR TITLE
feat: use status expiration to clear slack status

### DIFF
--- a/src/Lastfm.d.ts
+++ b/src/Lastfm.d.ts
@@ -1,5 +1,5 @@
 declare namespace LastFM {
-  interface Track {
+  interface RecentTrack {
     artist: {
       mbid: string
       '#text': string
@@ -22,6 +22,37 @@ declare namespace LastFM {
     mbid: string
   }
 
+  interface Tag {
+    name: string
+    url: string
+  }
+
+  interface Track {
+    name: string
+    url: string
+    duration: string
+    streamable: {
+      '#text': string
+      fulltrack: string
+    }
+    listeners: string
+    playcount: string
+    artist: {
+      name: string
+      mbid: string
+      url: string
+    }
+    album: {
+      artist: string
+      title: string
+      url: string
+      image: Image[]
+    }
+    toptags: {
+      tag: Tag[]
+    }
+  }
+
   interface Image {
     size: 'small' | 'medium' | 'large' | 'extralarge'
     /** URL */
@@ -29,7 +60,7 @@ declare namespace LastFM {
   }
 
   namespace APIResponse {
-    interface RecentTracks {
+    interface UserGetRecentTracks {
       recenttracks: {
         '@attr': {
           page: string
@@ -38,8 +69,12 @@ declare namespace LastFM {
           perPage: string
           totalPages: string
         }
-        track: Track[]
+        track: RecentTrack[]
       }
+    }
+
+    interface TrackGetInfo {
+      track: Track
     }
   }
 }

--- a/src/utils/__tests__/slack.test.ts
+++ b/src/utils/__tests__/slack.test.ts
@@ -1,4 +1,5 @@
-import { shouldSetStatus } from '../slack'
+import { shouldSetStatus, calcExpiration } from '../slack'
+import { getUnixTime } from 'date-fns'
 
 describe('slack', () => {
   describe('shouldSetStatus', () => {
@@ -27,6 +28,16 @@ describe('slack', () => {
       }
       const result = shouldSetStatus(profile as any)
       expect(result).toBeFalsy()
+    })
+  })
+
+  describe('calcExpiration', () => {
+    it('adds the duration to the current time', () => {
+      const result = calcExpiration(5 * 60 * 1000) // 5 min in ms
+      const now = getUnixTime(new Date())
+
+      expect(result).toBeGreaterThan(now)
+      expect(result).toBe(now + 300) // adds 300s/5min to current unix time
     })
   })
 })

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import { getNowPlaying } from '../lastFm'
 describe('lastfm', () => {
   describe('getNowPlaying', () => {
     it('returns a now playing track', () => {
-      const track: Partial<LastFM.Track> = {
+      const track: Partial<LastFM.RecentTrack> = {
         '@attr': {
           nowplaying: 'true'
         }
@@ -13,7 +13,7 @@ describe('lastfm', () => {
     })
 
     it('returns undefined when nowplaying = false', () => {
-      const track: Partial<LastFM.Track> = {
+      const track: Partial<LastFM.RecentTrack> = {
         '@attr': {
           nowplaying: 'false'
         }
@@ -23,7 +23,7 @@ describe('lastfm', () => {
     })
 
     it('returns undefined when @attr.nowplaying is undefined', () => {
-      const track: Partial<LastFM.Track> = {
+      const track: Partial<LastFM.RecentTrack> = {
         artist: {
           mbid: '',
           '#text': ''

--- a/src/utils/lastFm.ts
+++ b/src/utils/lastFm.ts
@@ -7,10 +7,10 @@ import { log } from './log'
  *
  * [API Doc](https://www.last.fm/api/show/user.getRecentTracks)
  */
-export async function getLastFmTrack (username: string) {
-  log('Getting track info', 'lastfm')
+export async function getRecentLastFmTracks (username: string) {
+  log(`Getting recent track info for "${config.lastFM.username}"`, 'lastfm')
 
-  type LastFMResponse = AxiosResponse<LastFM.APIResponse.RecentTracks>
+  type LastFMResponse = AxiosResponse<LastFM.APIResponse.UserGetRecentTracks>
   const url = `${config.lastFM.apiUrl}/?method=user.getrecenttracks`
   const opts = {
     params: {
@@ -29,7 +29,37 @@ export async function getLastFmTrack (username: string) {
     throw error
   }
 }
+
+/**
+ * Get the detailed track info given a track name and artist
+ *
+ * [API Doc](https://www.last.fm/api/show/track.getInfo)
+ */
+export async function getLastFmTrack (track: string, artist: string) {
+  log(`Getting track info for "${track}" by ${artist}`, 'lastfm')
+
+  type LastFMResponse = AxiosResponse<LastFM.APIResponse.TrackGetInfo>
+  const url = `${config.lastFM.apiUrl}/?method=track.getInfo`
+  const opts = {
+    params: {
+      artist,
+      track,
+      format: 'json',
+      api_key: config.lastFM.apiKey,
+      limit: 1
+    }
+  }
+
+  try {
+    const { data }: LastFMResponse = await axios.get(url, opts)
+    return data.track
+  } catch (error) {
+    if (error.response) throw Error(error.response.data.message)
+    throw error
+  }
+}
+
 /** Returns a LastFM track if it's considered now playing */
-export function getNowPlaying (tracks: LastFM.Track[]) {
+export function getNowPlaying (tracks: LastFM.RecentTrack[]) {
   return tracks.find(track => track['@attr']?.nowplaying === 'true')
 }


### PR DESCRIPTION
This will reduce the number of requests made to the slack API outside
active hours or when a custom status is set. It now relies solely on the
duration of the song to "unset" the users status.

Resolves #7 